### PR TITLE
Open the new tab instead of pages/blank.html

### DIFF
--- a/background_scripts/actions.js
+++ b/background_scripts/actions.js
@@ -17,7 +17,7 @@ callAction = function(action, config) {
   } else if (request.url) {
     url = request.url;
   } else {
-    url = "../pages/blank.html";
+    url = "chrome://newtab";
   }
   actions[action]();
 };


### PR DESCRIPTION
When we execute `:tabnew`, we expect to see the new tab page of Google Chrome.
