### PR TITLE
now goToRootUrl does not change state of tab (pin/unpinned)

### DIFF
--- a/background_scripts/actions.js
+++ b/background_scripts/actions.js
@@ -54,7 +54,7 @@ actions.openLink = function() {
   } else {
     chrome.tabs.update({
       url: url,
-      pinned: request.tab.pinned
+      pinned: sender.tab.pinned
     });
   }
 };


### PR DESCRIPTION
Hey. First thanks for this amazing extension.
I just stumbled upon this weird behavior that if you do a "gU" on a pinned site it will get unpinned but I'm not sure if my change solves this problem completely.
