### PR TITLE
Maintain pinned status of tab moved between windows

### DIFF
--- a/background_scripts/actions.js
+++ b/background_scripts/actions.js
@@ -214,10 +214,15 @@ actions.moveTab = function() {
     }).map(function(e) {
       return e.id;
     });
+    var wasPinned = sender.tab.pinned;
     if (info.indexOf(parseInt(request.windowId)) !== -1) {
       chrome.tabs.move(sender.tab.id, {
         windowId: parseInt(request.windowId),
         index: -1
+      }, function(tab) {
+        chrome.tabs.update(tab.id, {
+          pinned: wasPinned
+        });
       });
     }
   });


### PR DESCRIPTION
Hi,

Another PR regarding pinned tabs. If you `:tabattach` to another window, a pinned tab now remains pinned.

I also have a couple of other improvements to `:tabattach`:
1. Focus moved tab. I think this makes more sense. Whenever I use `:tabattach`, I still want the tab to be the current focus (like I would when I move a tab within a window with `<` and `>`).
2. `:tabattach 0` to move tab to a new window (and include "0 new window" in the completion). I don't believe there is another way to do this yet?

I haven't written them yet, but if they are features you would merge, let me know and I will.
