### PR TITLE
Enable completion for :session and :mksession

### DIFF
--- a/content_scripts/command.js
+++ b/content_scripts/command.js
@@ -397,6 +397,8 @@ Command.callCompletionFunction = (function() {
     case 'restore':
       restoreTabCompletion(value);
       return true;
+    case 'session':
+    case 'mksession':
     case 'delsession':
       deleteSessionCompletion(value);
       return true;


### PR DESCRIPTION
Auto-complete the available sessions that could be restored in the same
way that :delsession did. Also allow us to see which ones are available
to be overwritten by saving on top of an existing session when using
:mksession. Fixes #219