### PR TITLE
[WIP] possible fix for #281: input is lost when command frame is triggered during loading

### DIFF
--- a/background_scripts/actions.js
+++ b/background_scripts/actions.js
@@ -711,6 +711,12 @@ Actions = (function() {
     callback({type: 'parseRC', config: RCParser.parse(request.config)});
   };
 
+  _.commandFrameLoaded = function() {
+    chrome.tabs.sendMessage(sender.tab.id, {
+      action: request.action
+    });
+  };
+
   _.showCommandFrame = function() {
     chrome.tabs.sendMessage(sender.tab.id, {
       action: request.action,

--- a/content_scripts/command.js
+++ b/content_scripts/command.js
@@ -981,6 +981,19 @@ Command.callOnCvimLoad = (function() {
 })();
 
 Command.onDOMLoad = function() {
+  if (window.self === window.top) {
+    Command.frame = document.createElement('iframe');
+    Command.frame.src = chrome.runtime.getURL('cmdline_frame.html');
+    Command.frame.id = 'cVim-command-frame';
+    document.lastElementChild.appendChild(Command.frame);
+  } else {
+    this.onDOMLoadAll();
+    if (window.isCommandFrame)
+      PORT("commandFrameLoaded");
+  }
+}
+
+Command.onDOMLoadAll = function() {
   this.insertCSS();
   this.onBottom = settings.barposition === 'bottom';
   if (this.data !== void 0) {
@@ -1171,12 +1184,3 @@ Command.configureSettings = function(_settings) {
     this.init(false);
   }
 };
-
-if (window.self === window.top) {
-  Command.callOnCvimLoad(function() {
-    Command.frame = document.createElement('iframe');
-    Command.frame.src = chrome.runtime.getURL('cmdline_frame.html');
-    Command.frame.id = 'cVim-command-frame';
-    document.lastElementChild.appendChild(Command.frame);
-  });
-}

--- a/content_scripts/messenger.js
+++ b/content_scripts/messenger.js
@@ -234,6 +234,10 @@ chrome.extension.onMessage.addListener(function(request, sender, callback) {
       if (self === top)
         callback(Frames.getSubFrames());
       break;
+    case 'commandFrameLoaded':
+      if (!window.isCommandFrame && !Command.domElementsLoaded)
+        Command.onDOMLoadAll();
+      break;
     case 'showCommandFrame':
       if (Command.frame) {
         Command.frame.style.display = 'block';


### PR DESCRIPTION
_Tagging this as work in progress, since I'm not very comfortable with the project_

This change causes Command.domElementsLoaded to be delayed on window.top until the command frame completes loading.

Without it, you could lose input if you triggered a Command.show after window.top was loaded, but before the command frame was loaded.  Without the command frame listening for 'show/hideCommandFrame' messages, you'd end up with inconsistent visibility/focus states.