### PR TITLE
make function call in cVimrc support arguments

### DIFF
--- a/content_scripts/mappings.js
+++ b/content_scripts/mappings.js
@@ -835,9 +835,9 @@ Mappings.parseLine = function(line) {
             ECHO('callMapFunction', {
               name: map
             });
-          } else if (settings.FUNCTIONS[map]) {
+          } else {
             ECHO('eval', {
-              code: settings.FUNCTIONS[map] + '()'
+              code: map,
             });
           }
         });

--- a/content_scripts/messenger.js
+++ b/content_scripts/messenger.js
@@ -147,6 +147,12 @@ port.onMessage.addListener(function(response) {
         Mappings.parseCustom(response.settings.MAPPINGS);
         settings = response.settings;
       }
+      settings.functions = {};
+      var functionNames = Object.keys(settings.FUNCTIONS);
+      for(var i=0; i<functionNames.length; i++) {
+        var fn = functionNames[i];
+        settings.functions[fn] = eval(settings.FUNCTIONS[fn]);
+      }
       break;
     case 'updateLastCommand':
       if (request.data) {
@@ -301,7 +307,7 @@ chrome.extension.onMessage.addListener(function(request, sender, callback) {
           Mappings.actions[request.name](1);
           break;
         case 'eval':
-          eval(request.code);
+          eval("settings.functions."+request.code);
           break;
         }
       }


### PR DESCRIPTION
When mapping some keystroke to a function defined in cVimrc, it should be able to pass arguments to the function.

For example, I defined a function named searchWith, mapping to different keystrokes with different parameter as below.

    searchWith(se) -> {{
        var query = window.getSelection().toString();
        RUNTIME('openLink', {
            tab: {tabbed:true},
            url: se+encodeURI(query)
        });
    }}

    map <Leader>g :call searchWith("https://www.google.com/search?q=")<CR>
    map <Leader>b :call searchWith("https://www.baidu.com/s?wd=")<CR>


To keep code and use cases clean, an empty parenthesis should be followed when there is no argument.

    getIP() -> {{
        httpRequest({url: 'http://api.ipify.org/?format=json', json: true},
                function(res) { Status.setMessage('IP: ' + res.ip); });
    }}

    map ci :call getIP()<CR>
