### PR TITLE
Add ge command to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ let completionengines = ['google', 'google-image', 'youtube'] " Show only these 
 | `z0`                      | zoom page to original size                                            | zoomOrig                        |
 | `z<Enter>`                | toggle image zoom (same as clicking the image on image-only pages)    | toggleImageZoom                 |
 | `gd`                      | alias to :chrome://downloads&lt;CR&gt;                                | :chrome://downloads&lt;CR&gt;   |
+| `ge`                      | alias to :chrome://extensions&lt;CR&gt;                               | :chrome://extensions&lt;CR&gt;  |
 | `yy`                      | copy the URL of the current page to the clipboard                     | yankDocumentUrl                 |
 | `yY`                      | copy the URL of the current frame to the clipboard                    | yankRootUrl                     |
 | `ya`                      | copy the URLs in the current window                                   | yankWindowUrls                  |


### PR DESCRIPTION
I was looking through the mappings.js file and noticed that there is a ge command to open up Chrome Extensions that doesn't show up on the README.md file.  I thought it might help out your users to update the documentation.