### PR TITLE
Allow full css customization on search matches

### DIFF
--- a/content_scripts/find.js
+++ b/content_scripts/find.js
@@ -47,6 +47,7 @@ Find.search = function(reverse, repeats, ignoreFocus) {
   }
   if (this.index >= 0) {
     this.matches[this.index].style.backgroundColor = settings.highlight;
+    this.matches[this.index].className = 'cVim-find-mark';
   }
   if (reverse && repeats === 1 && this.index === 0) {
     this.index = this.matches.length - 1;
@@ -78,6 +79,7 @@ Find.search = function(reverse, repeats, ignoreFocus) {
   }
   var isLink = ignoreFocus ? false : this.focusParentLink(this.matches[this.index]);
   this.matches[this.index].style.backgroundColor = activeHighlight;
+  this.matches[this.index].className = 'cVim-find-mark active';
   HUD.display(this.index + 1 + ' / ' + this.matches.length);
   var paddingTop = 0,
       paddingBottom = 0;


### PR DESCRIPTION
This simple PR allows full css customization on search maches.

Example:
![Image of custom search maches](http://i.imgur.com/hRy1mQw.gif)

CSS used in the above example:
```css
/* orange/yellow - none, this is default */

/* orange/gray */
.cVim-find-mark {
  background-color: lightgray !important;
  border: 3px solid silver;
}

.cVim-find-mark.active {
  background-color: orange !important;
  border: 3px solid darkorange;
}

/* blue/gray */
.cVim-find-mark {
  border-radius: 0.25em;
  padding: 0.10em 0.20em;
  color: white;
  font-weight: bold !important;
  background: linear-gradient(to bottom, #E8E8E8 0%,#8C8C8C 100%) !important;
  text-shadow: 0 0 0.2em #8C8C8C;
}

.cVim-find-mark.active {
  background: linear-gradient(to bottom, #A8DAFF 0%,#027EFF 100%) !important;
  text-shadow: 0 0 0.2em #027EFF;
}
```

PS. You can add this example to README.md, if you want.