### PR TITLE
Fix for missing encoding in mappings.html

### DIFF
--- a/pages/changelog.html
+++ b/pages/changelog.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><link rel="stylesheet" href="./markdown.css"><link rel="stylesheet" href="../content_scripts/main.css"><script src="../content_scripts/session.js"></script>
+<!DOCTYPE html><html><head><meta charset="utf-8"><link rel="stylesheet" href="./markdown.css"><link rel="stylesheet" href="../content_scripts/main.css"><script src="../content_scripts/session.js"></script>
 <script src="../content_scripts/utils.js"></script>
 <script src="../content_scripts/dom.js"></script>
 <script src="../content_scripts/hints.js"></script>

--- a/pages/mappings.html
+++ b/pages/mappings.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><link rel="stylesheet" href="./markdown.css"><link rel="stylesheet" href="../content_scripts/main.css"><script src="../content_scripts/session.js"></script>
+<!DOCTYPE html><html><head><meta charset="utf-8"><link rel="stylesheet" href="./markdown.css"><link rel="stylesheet" href="../content_scripts/main.css"><script src="../content_scripts/session.js"></script>
 <script src="../content_scripts/utils.js"></script>
 <script src="../content_scripts/dom.js"></script>
 <script src="../content_scripts/hints.js"></script>

--- a/scripts/create_pages.js
+++ b/scripts/create_pages.js
@@ -40,6 +40,7 @@ var scripts = [
 
 var makeHTML = function(data) {
   return '<!DOCTYPE html><html><head>' +
+         '<meta charset="utf-8">' + 
          '<link rel="stylesheet" href="./markdown.css">' +
          '<link rel="stylesheet" href="../content_scripts/main.css">' +
          scripts.map(function(e) { return '<script src="../content_scripts/' + e + '.js"></script>'; }).join('\n') +


### PR DESCRIPTION
In mapping.html > cVim Help > cVimrc

previousmatchpattern and nextmatchpattern values in column "defaults" uses unicode symbols,
this requires utf-8 encoding to be specified in order to display these symbols correctly.

This is only visible when "mappings" page was open from :help, eg:
```vim
:help<CR>
/previousmatchpattern<CR>
zz
```

In the following screenshoots columns "type" and "description" were hidden for clarity.

Before (encoding guessed by chrome: ISO-8859-2):
![](http://i.imgur.com/aZ2JXDf.png)
After (encoding specified in tag meta: UTF-8):
![](http://i.imgur.com/fmAtlu8.png)