### PR TITLE
Manual (non-automatic) completion update

### DIFF
--- a/content_scripts/keys.js
+++ b/content_scripts/keys.js
@@ -387,8 +387,13 @@ var KeyHandler = {
       case '<S-Tab>':
         if (Command.type === 'action') {
           event.preventDefault();
-          Mappings.actions[ (key === '<Tab>' ? 'next' : 'previous') +
-                            'CompletionResult' ]();
+
+          if (Command.completionsNeedUpdate) {
+            Command.updateCompletions(true);
+          } else {
+            Mappings.actions[ (key === '<Tab>' ? 'next' : 'previous') +
+                              'CompletionResult' ]();
+          }
         }
         break;
       case '<C-p>':

--- a/content_scripts/messenger.js
+++ b/content_scripts/messenger.js
@@ -84,13 +84,13 @@ port.onMessage.addListener(function(response) {
       if (Command.historyMode) {
         if (Command.active && Command.bar.style.display !== 'none') {
           Command.completions = { history: matches };
-          Command.updateCompletions(false);
+          Command.markCompletionsForUpdate();
         }
       } else if (Command.searchMode) {
         Command.searchMode = false;
         if (Command.active && Command.bar.style.display !== 'none') {
           Command.completions.history = matches;
-          Command.updateCompletions(true);
+          Command.markCompletionsForUpdate();
         }
       }
       break;
@@ -118,7 +118,7 @@ port.onMessage.addListener(function(response) {
             return [ response.buffers[+val - 1] ] || [];
           })()
         };
-        Command.updateCompletions();
+        Command.markCompletionsForUpdate();
       }
       break;
     case 'sessions':
@@ -131,7 +131,7 @@ port.onMessage.addListener(function(response) {
       if (response.path.length) {
         Command.completions = {};
         Command.completions.paths = response.path;
-        Command.updateCompletions();
+        Command.markCompletionsForUpdate();
       } else {
         Command.hideData();
       }


### PR DESCRIPTION
Command completions (e.g. for 'open' commands) were previously automatically updated when command characters are being typed. I dislike this automatic behavior. With this commit the completion is only updated when TAB key is pressed.

The implementation is quite simple (see the commit diff), but maybe not very elegant since I only spent very little time learning the code base. Also, this should probably be an optional setting.

Does anybody have feedback about the idea or the implementation?