### PR TITLE
Allow empty 'completionengines' list

### DIFF
--- a/content_scripts/command.js
+++ b/content_scripts/command.js
@@ -1073,8 +1073,7 @@ Command.onDOMLoadAll = function() {
 
 Command.updateSettings = function(config) {
   var key;
-  if (Array.isArray(config.completionengines) &&
-      config.completionengines.length) {
+  if (Array.isArray(config.completionengines)) {
     Complete.engines = Complete.engines.filter(function(e) {
       return ~config.completionengines.indexOf(e);
     });


### PR DESCRIPTION
With this commit it is possible to have no completion engines enabled:

```
let completionengines = []
```

Previously, the empty configuration would be treated as an invalid value and thus the default value would be used instead.

Resolves #381.

Was there some reason for the length check on [content_scripts/command.js#L1077](https://github.com/1995eaton/chromium-vim/blob/71b39c8e8c9429e285ea4e9c5f60729f5c60e994/content_scripts/command.js#L1077)?