### PR TITLE
when opening new tabs, always open the blank page first and then redi…

### DIFF
--- a/background_scripts/actions.js
+++ b/background_scripts/actions.js
@@ -4,7 +4,20 @@ Actions = (function() {
 
   var lastCommand = null;
 
+  var queryStringify = function(obj) {
+    var str = [];
+    for(var p in obj)
+      if (obj.hasOwnProperty(p)) {
+        str.push(encodeURIComponent(p) + "=" + encodeURIComponent(obj[p]));
+      }
+    return str.join("&");
+  }
+
   var openTab = function(options, times) {
+    if(options.url !== '../pages/blank.html') {
+      var queryString = queryStringify({url: options.url});
+      options.url = '../pages/blank.html?' + queryString;
+    }
     times = +times || 1;
     var doOpen = function() {
       for (var i = 0; i < times; ++i)

--- a/content_scripts/blank.js
+++ b/content_scripts/blank.js
@@ -1,0 +1,19 @@
+(function() {
+
+  function get_params() {
+    var match,
+        pl     = /\+/g,  // Regex for replacing addition symbol with a space
+        search = /([^&=]+)=?([^&]*)/g,
+        decode = function (s) { return decodeURIComponent(s.replace(pl, " ")); },
+        query  = window.location.search.substring(1);
+
+    params = {};
+    while (match = search.exec(query))
+      params[decode(match[1])] = decode(match[2]);
+    return params;
+  }
+
+  var params = get_params();
+  if(params.url)
+    window.location.href = params.url;
+})();

--- a/pages/blank.html
+++ b/pages/blank.html
@@ -22,6 +22,7 @@
         <script src="../content_scripts/search.js"></script>
         <script src="../content_scripts/frames.js"></script>
         <script src="../content_scripts/messenger.js"></script>
+        <script src="../content_scripts/blank.js"></script>
         <link rel="stylesheet" href="../content_scripts/main.css">
     </head>
     <body>


### PR DESCRIPTION
…rect to the requested page.

Currently when we open a new tab and the internet is slow or the site is not available it might take seconds for *cvim* to be activated. my idea is to always open `./pages/blank.html` which loads *cvim* completely and then redirect to the requested page from `blank.html`.

I've implemented this by passing query string parameters to `blank.html`.
When `blank.html` is loaded, it checks the query string and redirects to the the requested page.