### PR TITLE
consistent search behavior - '%s' format vs append

### DIFF
--- a/content_scripts/complete.js
+++ b/content_scripts/complete.js
@@ -53,26 +53,28 @@ var Complete = {
       return '';
 
     input[0] = this.getAlias(input[0]) || input[0];
-    if (!this.hasEngine(input[0])) {
+    var engine = null;
+    if (this.hasEngine(input[0])) {
+      engine = this.getEngine(input[0]);
+      input = input.slice(1);
+      if (input.length == 0)
+	return engine.baseUrl;
+    } else {
       if (!isLink && (isURL || input.join(' ').validURL())) {
         input = input.join(' ');
         return (!/^[a-zA-Z\-]+:/.test(input) ? 'http://' : '') +
           input;
       }
-      var defaultEngine = this.getEngine(settings.defaultengine);
-      return (defaultEngine ? defaultEngine.requestUrl :
-                              this.getEngine('google').requestUrl) +
-        encodeURIComponent(input.join(' '));
+      engine = this.getEngine(settings.defaultengine) || this.getEngine('google');
     }
-
-    var engine = this.getEngine(input[0]);
-    if (input.length <= 1)
-      return engine.baseUrl;
 
     var prefix = engine.requestUrl;
     var suffix = engine.hasOwnProperty('formatRequest') ?
-      engine.formatRequest(input.slice(1).join(' ')) :
-      encodeURIComponent(input.slice(1).join(' '));
+      engine.formatRequest(input.join(' ')) :
+      encodeURIComponent(input.join(' '));
+
+    console.log('prefix: ', prefix)
+    console.log('suffix: ', suffix)
 
     if (suffix.validURL())
       return suffix.convertLink();


### PR DESCRIPTION
The following should result in the same search url, but they don't:

open DEFAULTENGINE needle
open? needle
open needle

If DEFAULTENGINE is configured as

let searchengine myengine = "http://my.engi.ne/search?q=%s"
let defaultengine = "myengine"

Then the 3 open commands result in:

http://my.engi.ne/search?q=needle  # OK
http://my.engi.ne/search?q=%sneedle  # ?
http://my.engi.ne/search?q=%sneedle  # ?

This fix makes the behavior consistent regardless of whether or not the
search engine to use is explicit; from README.md -

> If you leave out the '%s' at the end of the URL,
> your query will be appended to the link.
> Otherwise, your query will replace the '%s'.