### PR TITLE
Set globals format for pegjs

### DIFF
--- a/cvimrc_parser/Makefile
+++ b/cvimrc_parser/Makefile
@@ -1,5 +1,5 @@
 all:
-	../node_modules/pegjs/bin/pegjs -e RCParser parser.peg && cp parser.js ../content_scripts/cvimrc_parser.js
+	../node_modules/pegjs/bin/pegjs --format globals -e RCParser parser.peg && cp parser.js ../content_scripts/cvimrc_parser.js
 
 test: all
 	node ./test/test.js


### PR DESCRIPTION
Fixes make error `Can't use the -e/--export-var option with the "commonjs" module format.`
