### PR TITLE
Fix #390

### DIFF
--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -161,8 +161,10 @@ var Listeners = {
         chrome.tabs.query({active: true, currentWindow: true}, function(tab) {
           chrome.tabs.sendMessage(tab[0].id, {
             action: 'nextCompletionResult'
-          }, function() {
-            chrome.windows.create({url: 'chrome://newtab'});
+          }, function(res) {
+            if(res == true){
+              chrome.windows.create({url: 'chrome://newtab'});
+            }
           });
         });
         break;


### PR DESCRIPTION
nextCompletionResult is working, but Chrome opens new tab at the same moment because chrome.tabs.sendMessage() gets "undefined"
I don't know why it gets "undefined", but I think new tab should be opened when sendMessage() gets only  "true"