### PR TITLE
update scroll history before scrolling

### DIFF
--- a/content_scripts/scroll.js
+++ b/content_scripts/scroll.js
@@ -309,6 +309,7 @@ Scroll.scroll = function(type, repeats) {
   var shouldLogPosition = !/^(up|down|left|right|pageUp|pageDown)$/.test(type);
   if (document.body && shouldLogPosition) {
     this.lastPosition = [document.scrollingElement.scrollLeft, document.scrollingElement.scrollTop];
+    Scroll.addHistoryState();
   }
 
   var direction = (function() {
@@ -370,16 +371,8 @@ Scroll.scroll = function(type, repeats) {
   }
 
   if (settings && settings.smoothscroll) {
-    if (shouldLogPosition) {
-      window.smoothScrollBy(scrollElem, x, y, settings.scrollduration,
-        function() { Scroll.addHistoryState(); });
-    } else {
-      window.smoothScrollBy(scrollElem, x, y, settings.scrollduration);
-    }
+    window.smoothScrollBy(scrollElem, x, y, settings.scrollduration);
   } else {
     $scrollBy(scrollElem, x, y);
-    if (shouldLogPosition)
-      Scroll.addHistoryState();
   }
-
 };


### PR DESCRIPTION
Scroll history should be updated before scrolling so that issuing <C-o>
can take the user back to where they were before the scroll was
initiated. This matches the behavior that vim uses more closely than the
current implementation does.

With this patch it should be possible to merge the functionality of
lastLocation into the HistoryState as well, since the previous index
in the jump list should always be the location that `''` should jump to.

The in callback argument to scrollSmoothlyToPosition should possibly be
removed as well, since I think it was added for the patch that added the
jumplist.