### PR TITLE
Avoid command action when key is typed in IME

### DIFF
--- a/content_scripts/keys.js
+++ b/content_scripts/keys.js
@@ -738,6 +738,10 @@ var KeyHandler = {
     }
 
     if (Command.commandBarFocused()) {
+      // If key event ocurred in IME and the key is not regular one,
+      // set key vaule empty to avoid action.
+      if (event.isComposing && /^<.*>$/.test(key))
+        key = '';
       window.setTimeout(function() {
         Command.lastInputValue = Command.input.value;
       }, 0);


### PR DESCRIPTION
If you are unfamiliar with IME, please read this article.
[Handling IME events in JavaScript – Not Rocket Science](https://www.stum.de/2016/06/24/handling-ime-events-in-javascript/)
In the article, IME is handled with compositionstart event and compositionend event, but I used [KeyboardEvent.isComposing](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing) instead.