### PR TITLE
Enable to copy HTML Formatted Link

### DIFF
--- a/background_scripts/actions.js
+++ b/background_scripts/actions.js
@@ -35,6 +35,12 @@ Actions = (function() {
     o.callback(o.sender.tab.url);
   };
 
+  _.getRootUrlLink = function(o) {
+    var url = o.sender.tab.url;
+    var title = o.sender.tab.title;
+    o.callback('<a href="' + url + '">' + title + '</a>');
+  };
+
   _.viewSource = function(o) {
     o.url = 'view-source:' + o.sender.tab.url;
     _.openLink(o);
@@ -339,6 +345,10 @@ Actions = (function() {
 
   _.copy = function(o) {
     Clipboard.copy(o.request.text);
+  };
+
+  _.copyHtmlFormatted = function(o) {
+    Clipboard.copyHtmlFormatted(o.request.html);
   };
 
   _.goToTab = function(o) {

--- a/background_scripts/clipboard.js
+++ b/background_scripts/clipboard.js
@@ -16,6 +16,19 @@ Clipboard.copy = function(text) {
   document.body.removeChild(t);
 };
 
+Clipboard.copyHtmlFormatted = function(html) {
+  var wrapper = document.createElement('div');
+  wrapper.innerHTML = html;
+  document.body.appendChild(wrapper);
+  var r = document.createRange();
+  r.selectNode(wrapper);
+  var s = window.getSelection();
+  s.removeAllRanges();
+  s.addRange(r);
+  document.execCommand('Copy');
+  wrapper.remove();
+};
+
 Clipboard.paste = function() {
   var t = this.createTextArea();
   document.body.appendChild(t);

--- a/content_scripts/clipboard.js
+++ b/content_scripts/clipboard.js
@@ -8,6 +8,14 @@ var Clipboard = {
     }
     RUNTIME('copy', {text: this.store});
   },
+  copyHtmlFormatted: function(html, store) {
+    if (!store) {
+      this.store = html;
+    } else {
+      this.store += (this.store.length ? '\n' : '') + html;
+    }
+    RUNTIME('copyHtmlFormatted', {html: this.store});
+  },
   paste: function(tabbed) {
     var engineUrl = Complete.getEngine(settings.defaultengine);
     engineUrl = engineUrl ? engineUrl.requestUrl :

--- a/content_scripts/mappings.js
+++ b/content_scripts/mappings.js
@@ -445,6 +445,12 @@ Mappings.actions = {
       Status.setMessage(url, 2);
     });
   },
+  yankDocumentUrlHtmlFormatted: function() {
+    RUNTIME('getRootUrlLink', function(link) {
+      Clipboard.copyHtmlFormatted(link);
+      Status.setMessage(link, 2);
+    });
+  },
   yankFrameUrl: function() {
     Clipboard.copy(document.URL);
     Status.setMessage(document.URL, 2);


### PR DESCRIPTION
I created a mapping, yankDocumentUrlHtmlFormatted.
This feature is useful to paste to rich editor.

ref. https://stackoverflow.com/questions/25657626/how-to-copy-html-formatted-text-on-to-clipboard-from-google-chrome-extension/25662380#25662380