### PR TITLE
Enable to copy HTML Formatted Link revised

### DIFF
--- a/background_scripts/actions.js
+++ b/background_scripts/actions.js
@@ -35,10 +35,13 @@ Actions = (function() {
     o.callback(o.sender.tab.url);
   };
 
-  _.getRootUrlLink = function(o) {
-    var url = o.sender.tab.url;
-    var title = o.sender.tab.title;
-    o.callback('<a href="' + url + '">' + title + '</a>');
+  _.getRootUrlObj = function(o) {
+    o.callback({
+      a: {
+        '@href': o.sender.tab.url,
+        '_': o.sender.tab.title
+      }
+    });
   };
 
   _.viewSource = function(o) {
@@ -348,7 +351,7 @@ Actions = (function() {
   };
 
   _.copyHtmlFormatted = function(o) {
-    Clipboard.copyHtmlFormatted(o.request.html);
+    Clipboard.copyHtmlFormatted(o.request.nodeObj);
   };
 
   _.goToTab = function(o) {

--- a/background_scripts/actions.js
+++ b/background_scripts/actions.js
@@ -35,6 +35,12 @@ Actions = (function() {
     o.callback(o.sender.tab.url);
   };
 
+  _.getRootUrlLink = function(o) {
+    var url = o.sender.tab.url;
+    var title = o.sender.tab.title;
+    o.callback('<a href="' + url + '">' + title + '</a>');
+  };
+
   _.viewSource = function(o) {
     o.url = 'view-source:' + o.sender.tab.url;
     _.openLink(o);
@@ -339,6 +345,10 @@ Actions = (function() {
 
   _.copy = function(o) {
     Clipboard.copy(o.request.text);
+  };
+
+  _.copyHtmlFormatted = function(o) {
+    Clipboard.copyHtmlFormatted(o.request.html);
   };
 
   _.goToTab = function(o) {

--- a/background_scripts/clipboard.js
+++ b/background_scripts/clipboard.js
@@ -16,10 +16,25 @@ Clipboard.copy = function(text) {
   document.body.removeChild(t);
 };
 
-Clipboard.copyHtmlFormatted = function(html) {
+Clipboard.copyHtmlFormatted = function(nodeObj) {
+  var convertToNode = function(parent, nodeObj) {
+    for (var key in nodeObj) {
+      if (key.indexOf('@') === 0) {
+        parent.setAttribute(key.substr(1), nodeObj[key]);
+      } else if (key === '_') {
+        var child = document.createTextNode(nodeObj[key]);
+        parent.appendChild(child);
+      } else {
+        var tag = document.createElement(key);
+        parent.appendChild(convertToNode(tag, nodeObj[key]));
+      }
+    }
+    return parent;
+  };
+
   var wrapper = document.createElement('div');
-  wrapper.innerHTML = html;
-  document.body.appendChild(wrapper);
+  var node = convertToNode(wrapper, nodeObj);
+  document.body.appendChild(node);
   var r = document.createRange();
   r.selectNode(wrapper);
   var s = window.getSelection();

--- a/background_scripts/clipboard.js
+++ b/background_scripts/clipboard.js
@@ -16,6 +16,19 @@ Clipboard.copy = function(text) {
   document.body.removeChild(t);
 };
 
+Clipboard.copyHtmlFormatted = function(html) {
+  var wrapper = document.createElement('div');
+  wrapper.innerHTML = html;
+  document.body.appendChild(wrapper);
+  var r = document.createRange();
+  r.selectNode(wrapper);
+  var s = window.getSelection();
+  s.removeAllRanges();
+  s.addRange(r);
+  document.execCommand('Copy');
+  wrapper.remove();
+};
+
 Clipboard.paste = function() {
   var t = this.createTextArea();
   document.body.appendChild(t);

--- a/content_scripts/clipboard.js
+++ b/content_scripts/clipboard.js
@@ -8,6 +8,14 @@ var Clipboard = {
     }
     RUNTIME('copy', {text: this.store});
   },
+  copyHtmlFormatted: function(html, store) {
+    if (!store) {
+      this.store = html;
+    } else {
+      this.store += (this.store.length ? '\n' : '') + html;
+    }
+    RUNTIME('copyHtmlFormatted', {html: this.store});
+  },
   paste: function(tabbed) {
     var engineUrl = Complete.getEngine(settings.defaultengine);
     engineUrl = engineUrl ? engineUrl.requestUrl :

--- a/content_scripts/clipboard.js
+++ b/content_scripts/clipboard.js
@@ -8,13 +8,8 @@ var Clipboard = {
     }
     RUNTIME('copy', {text: this.store});
   },
-  copyHtmlFormatted: function(html, store) {
-    if (!store) {
-      this.store = html;
-    } else {
-      this.store += (this.store.length ? '\n' : '') + html;
-    }
-    RUNTIME('copyHtmlFormatted', {html: this.store});
+  copyHtmlFormatted: function(nodeObj) {
+    RUNTIME('copyHtmlFormatted', {nodeObj: nodeObj});
   },
   paste: function(tabbed) {
     var engineUrl = Complete.getEngine(settings.defaultengine);

--- a/content_scripts/mappings.js
+++ b/content_scripts/mappings.js
@@ -445,6 +445,12 @@ Mappings.actions = {
       Status.setMessage(url, 2);
     });
   },
+  yankDocumentUrlHtmlFormatted: function() {
+    RUNTIME('getRootUrlLink', function(link) {
+      Clipboard.copyHtmlFormatted(link);
+      Status.setMessage(link, 2);
+    });
+  },
   yankFrameUrl: function() {
     Clipboard.copy(document.URL);
     Status.setMessage(document.URL, 2);

--- a/content_scripts/mappings.js
+++ b/content_scripts/mappings.js
@@ -446,9 +446,9 @@ Mappings.actions = {
     });
   },
   yankDocumentUrlHtmlFormatted: function() {
-    RUNTIME('getRootUrlLink', function(link) {
-      Clipboard.copyHtmlFormatted(link);
-      Status.setMessage(link, 2);
+    RUNTIME('getRootUrlObj', function(nodeObj) {
+      Clipboard.copyHtmlFormatted(nodeObj);
+      Status.setMessage('copied', 2);
     });
   },
   yankFrameUrl: function() {


### PR DESCRIPTION
I modified https://github.com/1995eaton/chromium-vim/pull/591 to not use innerHTML.

Argument message of [chrome.runtime.sendMessage](https://developer.chrome.com/extensions/runtime#method-sendMessage) must be JSON-ifiable object. Node element is not JSON-ifiable, so I use an object. I made it referring to [tyrasd/jxon: lossless JavaScript XML Object Notation](https://github.com/tyrasd/jxon).

By your suggestion, one can copy `<a href="example.com">title</a>` string.
But my PR makes one can copy [title](example.com)