### PR TITLE
Fix #680 Unchecked runtime.lastError

### DIFF
--- a/content_scripts/messenger.js
+++ b/content_scripts/messenger.js
@@ -324,4 +324,6 @@ chrome.extension.onMessage.addListener(function(request, sender, callback) {
     callback(e.innerWidth > 5 && e.innerHeight > 5);
     break;
   }
+
+  return true;
 });


### PR DESCRIPTION
First of all, thanks for the great extension. I originally disabled this plugin because the error message was too annoying. But I already forgot how to use chrome without cVim, so here I am to fix it.

As described in #680, there is an error message from chrome after the extension is loaded. According to this [post](https://bugs.chromium.org/p/chromium/issues/detail?id=586155#c9), it turns out this is caused by `sendMessage` not getting any feedback from the listener. So returning true from the message listener solved the problem.