### PR TITLE
Updated creating a shadow root to use Shadow DOM v1 spec. This fixes …

### DIFF
--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -37,9 +37,9 @@ Hints.matchPatterns = function(pattern) {
   var link = null;
   for (var i = 0; i < applicableFilters.length; i++) {
     link = findFirstOf(document.querySelectorAll(applicableFilters[i]),
-        function(e) {
-          return DOM.isVisible(e);
-        });
+      function(e) {
+        return DOM.isVisible(e);
+      });
     if (link !== null)
       break;
   }
@@ -724,7 +724,7 @@ Hints.create = function(type, multi) {
     main.id = 'cVim-link-container';
     main.top = document.scrollingElement.scrollTop + 'px';
     main.left = document.scrollingElement.scrollLeft + 'px';
-    Hints.shadowDOM = main.createShadowRoot();
+    Hints.shadowDOM = main.attachShadow({ mode: 'open' });
 
     try {
       document.lastChild.appendChild(main);


### PR DESCRIPTION
…the broken hints functionality as of Chrome 80.0.3955.4.

Chrome 80.0.3955.4 and beyond follows v1 of the [Shadow DOM spec](https://hayatoito.github.io/2016/shadowdomv1/). The `element.createShadowRoot()` function has been deprecated and replaced with `element.attachShadow({ mode: 'open' })` for an _open_ shadow root.

Fixes #716 