### PR TITLE
Replace deprecated `createShadowRoot` method

### DIFF
--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -724,7 +724,7 @@ Hints.create = function(type, multi) {
     main.id = 'cVim-link-container';
     main.top = document.scrollingElement.scrollTop + 'px';
     main.left = document.scrollingElement.scrollLeft + 'px';
-    Hints.shadowDOM = main.createShadowRoot();
+    Hints.shadowDOM = main.attachShadow({mode: "closed"});
 
     try {
       document.lastChild.appendChild(main);


### PR DESCRIPTION
This method was deprecated and doesn't work anymore in chrome `80.0.3987.87` (possibly earlier).